### PR TITLE
Add discoverable RSS link

### DIFF
--- a/website/_includes/layout/head-meta.njk
+++ b/website/_includes/layout/head-meta.njk
@@ -23,6 +23,8 @@
 
 <meta name="google-site-verification" content="q30M0p1A4chHEQhW3ypsQYO7sz1EU7ACd3ng6IXqu-I"/>
 
+<link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="https://martinschneider.me/articles/feed.xml">
+
 {% if metaRobots %}
     <meta name="robots" content="{{ metaRobots }}"/>
 {% endif %}


### PR DESCRIPTION
Was just reorganizing some blogs into Reeder which couldn't detect a feed by itself.